### PR TITLE
Improve log orphan techniques

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Provides utility functions used by plugin.
+ *
+ * @package     local_chatlogs
+ * @copyright   2016 Andrew Nicols <andrew@nicols.co.uk>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_chatlogs;
+
+/**
+ * Provides utility functions used by plugin.
+ *
+ * @copyright   2016 Andrew Nicols <andrew@nicols.co.uk>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class util {
+    /**
+     * Group orphaned conversations.
+     *
+     * @return  array   The list of orphaned conversations which were re-grouped with another conversation.
+     *                  The array contains the conversation moved => where it was moved to.
+     */
+    public static function group_orphans() {
+        global $DB;
+        // Clean up orphan conversations.
+        $sql = <<<EOF
+                SELECT c.id, c.messagecount, COUNT(m.id) AS actualcount
+                FROM {local_chatlogs_conversations} c
+            INNER JOIN {local_chatlogs_messages} m ON m.conversationid = c.id
+            GROUP BY c.id, c.messagecount
+            ORDER BY c.id DESC
+EOF;
+
+        $moved = [];
+        if ($conversations = $DB->get_records_sql($sql)) {
+            // Skip the first conversation - it is still in progress.
+            array_shift($conversations);
+
+            $sourceid = 0;
+            foreach ($conversations as $conversation) {
+                if ($sourceid) {
+                    $moved[$sourceid] = $conversation->id;
+
+                    // Move messages to the target conversation.
+                    $DB->set_field('local_chatlogs_messages', 'conversationid', $conversation->conversationid, ['conversationid'  => $sourceid]);
+                    $DB->set_field('local_chatlogs_conversations', 'messagecount', 0, ['id'  => $sourceid]);
+
+                    // Update the count, and timeend on the target conversation.
+                    $conversation->messagecount = $DB->count_records('local_chatlogs_messages', ['conversationid' => $conversation->id]);
+                    $conversation->timeend = $DB->get_field_sql('SELECT timesent FROM {local_chatlogs_messages} WHERE conversationid = ? ORDER BY timesent DESC', [$conversation->id]);
+                    $DB->update_record('local_chatlogs_conversations', $conversation);
+
+                    // Clear the source value.
+                    $sourceid = 0;
+                }
+
+                if ($conversation->messagecount == 1 || $conversation->actualcount == 1) {
+                    // There is only a single message in the conversation.
+                    // Push this to the next conversation.
+                    $sourceid = $conversation->conversationid;
+                }
+            }
+        }
+
+        return $moved;
+    }
+}

--- a/cleanlogs.php
+++ b/cleanlogs.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+define('CLI_SCRIPT', true);
+require(__DIR__ . '/../../config.php');
+
+$transaction = $DB->start_delegated_transaction();
+
+$changes = [
+    'messagecount'  => 0,
+    'timeend'       => 0,
+    'orphaned'      => 0,
+];
+
+
+// Clean up orphan conversations.
+$moved = local_chatlogs\util::group_orphans();
+$changes['orphaned'] = count($moved);
+
+// Now tidy up any orphans.
+$sql = <<<EOF
+        SELECT c.id, c.messagecount, COUNT(m.id) AS actualcount
+          FROM {local_chatlogs_conversations} c
+    INNER JOIN {local_chatlogs_messages} m ON m.conversationid = c.id
+      GROUP BY c.id, c.messagecount
+      ORDER BY c.id DESC
+EOF;
+
+if ($conversations = $DB->get_records_sql($sql)) {
+    // Skip the first conversation - it is still in progress.
+    array_shift($conversations);
+
+    $sourceid = 0;
+    foreach ($conversations as $conversation) {
+        if ($sourceid) {
+            echo "\tOrphan:\t{$sourceid} => {$conversation->id}\n";
+
+            // Move messages to the target conversation.
+            $DB->set_field('local_chatlogs_messages', 'conversationid', $conversation->conversationid, ['conversationid'  => $sourceid]);
+            $DB->set_field('local_chatlogs_conversations', 'messagecount', 0, ['id'  => $sourceid]);
+
+            // Update the count, and timeend on the target conversation.
+            $conversation->messagecount = $DB->count_records('local_chatlogs_messages', ['conversationid' => $conversation->id]);
+            $conversation->timeend = $DB->get_field_sql('SELECT timesent FROM {local_chatlogs_messages} WHERE converationid = ? ORDER BY timesent DESC', [$converation->id]);
+            $DB->update_record('local_chatlogs_conversations', $conversation);
+
+            // Clear the source value.
+            $sourceid = 0;
+
+            $changes['orphaned']++;
+        }
+
+        if ($conversation->messagecount == 1 || $conversation->actualcount == 1) {
+            // There is only a single message in the conversation.
+            // Push this to the next conversation.
+            $sourceid = $conversation->conversationid;
+        }
+    }
+}
+
+$DB->commit_delegated_transaction($transaction);
+
+echo "\n";
+echo "============================================================================\n";
+echo "= Finished cleaning conversations.\n";
+echo "== Updated message counts:\t{$changes['messagecount']}\n";
+echo "== Updated timeend values:\t{$changes['timeend']}\n";
+echo "== Orphaned conversations:\t{$changes['orphaned']}\n";
+echo "============================================================================\n";
+echo "\n";

--- a/syncchatlogs.php
+++ b/syncchatlogs.php
@@ -129,26 +129,5 @@ if (!isset($ismoodlebot)) {
     echo "Synchronised chat logs ($count new messages) - URL: http://moodle.org/local/chatlogs/index.php?conversationid=".$conversationid."\n";
 }
 
-// Clean up orphan conversations
-
-$firstone = true;
-$pushtonext = 0;
-
-if ($conversations = $DB->get_records('local_chatlogs_conversations', null, 'conversationid desc')) {
-
-    foreach ($conversations as $conversation) {
-
-        if ($pushtonext) {  // Copy those to this
-            $DB->execute("UPDATE {local_chatlogs_messages} SET conversationid = $conversation->conversationid WHERE conversationid = ?", array($pushtonext));
-            $DB->execute("UPDATE {local_chatlogs_conversations} SET messagecount = 0 WHERE conversationid = ?", array($pushtonext));
-            $pushtonext = 0;
-        }
-
-        if (!$firstone && $conversation->messagecount == 1) {
-            $pushtonext = $conversation->conversationid;
-        }
-
-        $firstone = false;
-    }
-
-}
+// Clean up orphan conversations.
+local_chatlogs_group_orphans();


### PR DESCRIPTION
In some situations, logs are orphaned from their conversations.
I suspect that this is due to type checks in the update.

I've updated the behaviour to:
- check both conversation.messagecount and the actual message count;
- update the conversation timeend and messagecount more accurately; and
- switch to use of set_field instead of execute for DB updates.

I've also provided a script to fix the broken data.

I haven't (yet) tested this - I'll need to dump the DB and verify that the cleanup script works and haven't had a chance to do so today.
