### PR TITLE
HQ-1428 Add capability to pull logs from telegram api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.6
+ - 7.0
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_32_STABLE
+ matrix:
+  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^1
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpunit

--- a/classes/task/sync_chatlogs.php
+++ b/classes/task/sync_chatlogs.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A scheduled task for syning chatlogs from the remote api.
+ *
+ * @package    local_chatlogs
+ * @copyright  2017 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace local_chatlogs\task;
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A scheduled task for syning chatlogs from the remote api.
+ *
+ * @package    local_chatlogs
+ * @copyright  2017 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class sync_chatlogs extends \core\task\scheduled_task {
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('syncchatlogs', 'local_chatlogs');
+    }
+
+    /**
+     * Sync chatlogs
+     */
+    public function execute() {
+        $url = get_config('local_chatlogs', 'apiurl');
+        $secret = get_config('local_chatlogs', 'apisecret');
+        if (empty($url)) {
+            mtrace('local_chatlogs/apiurl is not configured, nothing to do.');
+            return;
+        } else if (empty($secret)) {
+            throw new \moodle_exception('API url is configured, but no secret is set.');
+        }
+
+        mtrace("Syncing chatlogs from {$url}");
+        $importer = new \local_chatlogs\telegram_importer($url, $secret);
+        $count = $importer->import();
+        mtrace("Chatlogs sync complete. {$count} messages synced.");
+    }
+}

--- a/classes/telegram_importer.php
+++ b/classes/telegram_importer.php
@@ -1,0 +1,235 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Imports logs from a simple json api provided by hubot-log-to-pgsql.
+ *
+ * @package     local_chatlogs
+ * @copyright   2017 Dan Poltawski <dan@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_chatlogs;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir .'/filelib.php');
+
+/**
+ * Imports logs from a simple json api provided by hubot-log-to-pgsql.
+ *
+ * @package     local_chatlogs
+ * @copyright   2017 Dan Poltawski <dan@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class telegram_importer {
+    /** @var int Number of seconds between conversations to start a new one */
+    const CONVERSATION_GAP = HOURSECS;
+    /** @var string url to telegram logs api */
+    protected $apiurl = '';
+    /** @var string secret which allows access to the api */
+    protected $secret = '';
+    /** @var array of user aliases which are already stored */
+    protected $participantscache = [];
+
+    /**
+     * Constructor.
+     *
+     * @param string $apiurl url for telegram logs api
+     * @param string $apisecret secret which allows access to the api
+     */
+    public function __construct($apiurl, $apisecret) {
+        $this->apiurl = $apiurl;
+        $this->secret = $apisecret;
+    }
+
+    /**
+     * Import the logs from the REST api.
+     *
+     * @return int number of logs imported
+     */
+    public function import() {
+        global $DB;
+
+        $transaction = $DB->start_delegated_transaction();
+
+        $sql = "SELECT conversationid, timesent, timejava
+                  FROM {local_chatlogs_messages}
+                ORDER BY timejava DESC LIMIT 1";
+        $lastmessage = $DB->get_record_sql($sql, null, IGNORE_MISSING);
+        if (!$lastmessage) {
+            $lastmessage = new \stdClass;
+            $lastmessage->conversationid = 0;
+            $lastmessage->timesent = 0;
+            $lastmessage->timejava = 0;
+        }
+
+        $remotemessages = $this->get_logs_from_api($lastmessage->timejava);
+
+        foreach ($remotemessages as $remotemessage) {
+            $message = $this->format_telegram_message($remotemessage);
+            $conversation = $this->get_or_create_conversation($message, $lastmessage);
+
+            $message->conversationid = $conversation->conversationid;
+            $message->id = $DB->insert_record('local_chatlogs_messages', $message);
+            $this->record_partcipant($message);
+
+            $lastmessage = $message;
+        }
+
+        // In previous implementation we handled 'orphaned' messages by moving them between conversations.
+        // This is intentionally ignored for now as it seems to be the source of bugs and isn't clear
+        // it's worth it (https://github.com/moodlehq/moodle-local_chatlogs/pull/8).
+        $transaction->allow_commit();
+        return count($remotemessages);
+    }
+
+    /**
+     * Call the logs api and return an array of chatlogs since the speicifed
+     * time
+     *
+     * @param int $milisecondtimestamp miliseconds since epoch timestamp to retrieve logs since
+     * @return int number of logs imported
+     */
+    protected function get_logs_from_api($milisecondtimestamp = 0) {
+        $url = new \moodle_url($this->apiurl);
+
+        if ($milisecondtimestamp) {
+            // Go from our milisecond timestamp to ISO-8601.
+            $formated = sprintf('%.4f', ($milisecondtimestamp / 1000));
+            $ts = \DateTime::createFromFormat('U.u', $formated);
+            // Sadly php built in ISO-8601 formaters strip the milliseconds, we have
+            // to format the date ourselves as we need the precesion.
+            $url->param('aftertimestamp', $ts->format('Y-m-d\TH:i:s.uP'));
+        }
+
+        $json = $this->call_api($url);
+        $logs = json_decode($json);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \moodle_exception("JSON response from API was invalid");
+        }
+        return $logs;
+    }
+
+    /**
+     * Call the REST api and return the response
+     *
+     * @param \moodle_url $url to call
+     * @return mixed response from server
+     */
+    protected function call_api(\moodle_url $url) {
+        $data = json_encode(['secret' => $this->secret]);
+        $curl = new \curl();
+        $curl->setHeader('Content-Type: application/json');
+        $response = $curl->post($url,  $data);
+        if ($curl->info['http_code'] !== 200) {
+            throw new \moodle_exception("Invalid response code from {$this->apiurl}: {$curl->info['http_code']}");
+        }
+        return $response;
+    }
+
+    /**
+     * Format a chatlog message from the telegram api into the format local_chatlogs_messages
+     * table expects.
+     *
+     * @param \stdClass $input chatlog entry from api
+     * @return \stdClass chatlog entry formated for the local_chatlogs_messages table
+     */
+    protected function format_telegram_message($input) {
+        $message = new \stdClass;
+        $message->fromemail = $input->username . '@telegram.me';
+        $message->fromnick = $input->fullname;
+        $message->message = $input->message;
+
+        // We are doing a bit of date weirdness here to ensure we have
+        // the timestamp stored with microseconds precision, which is important
+        // for ensuring that we don't retrieve the same chat message twice.
+        // $message->timestamp - traditional Moodle timestamp (Seconds since the Unix Epoch)
+        // $message->timejava - microseconds since unix epoch (so that we can later)
+        $d = new \DateTime($input->timestamp); // Input is ISO-8601 formated timestamp
+        $timestamp = $d->format('U'); // Time since epoch.
+        $miliseconds = $d->format('u') / 1000; // If php7 we could use ->format('v').
+        $milisecondepoch = floor(($timestamp * 1000) + $miliseconds);
+
+        $message->timesent = $timestamp;
+        $message->timejava = $milisecondepoch;
+
+        // The following are fields which don't make as much sense in the post-jabber
+        // world, and perhaps we'll get rid of?
+        $message->fromplace = 'telegram-import';
+
+        return $message;
+    }
+
+    /**
+     * Gets or creates the local_chatlogs_conversations record for which the chatlog
+     * message should be associated with.
+     *
+     * This function either create a new conversation record or retrieve the existing
+     * conversation which the message should be assocaited with, depending on whether the
+     * message is within self::CONVERSATION_GAP.
+     *
+     * @param \stdClass $message the message we are inserting into conversation
+     * @param \stdClass $previousmessage the most recent message added to the logs
+     * @return \stdClass conversation record
+     */
+    protected function get_or_create_conversation($message, $previousmessage) {
+        global $DB;
+
+        if ($message->timesent - $previousmessage->timesent < self::CONVERSATION_GAP) {
+            // Part of existing conversation.
+            $conversation = $DB->get_record('local_chatlogs_conversations',
+                ['conversationid' => $previousmessage->conversationid], '*', MUST_EXIST);
+            $conversation->timeend = $message->timesent;
+            $conversation->messagecount = $conversation->messagecount + 1;
+            $DB->update_record('local_chatlogs_conversations', $conversation);
+        } else {
+            // Create a new conversation.
+            $conversation = new \stdClass;
+            // The 'conversationid' is our own, manual id numbering..
+            $conversation->conversationid = $previousmessage->conversationid + 1;
+            $conversation->timestart = $message->timesent;
+            $conversation->timeend = $message->timesent + 1;
+            $conversation->messagecount = 1;
+            $DB->insert_record('local_chatlogs_conversations', $conversation);
+        }
+        return $conversation;
+    }
+
+    /**
+     * Records the chat participant in local_chatlogs_participants table.
+     *
+     * @param \stdClass $message the message we are inserting into conversation
+     */
+    protected function record_partcipant($message) {
+        global $DB;
+        if (isset($this->participantscache[$message->fromemail])) {
+            return;
+        }
+
+        if ($DB->record_exists('local_chatlogs_participants', ['fromemail' => $message->fromemail])) {
+            $this->participantscache[$message->fromemail] = true;
+            return;
+        }
+
+        $participant = new \stdClass;
+        $participant->fromemail = $message->fromemail;
+        $participant->nickname = $message->fromnick;
+        $DB->insert_record('local_chatlogs_participants', $participant);
+        $this->participantscache[$message->fromemail] = true;
+    }
+}

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -15,20 +15,23 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version details.
+ * Definition of partner block tasks
  *
- * @package    local_chatlogs
- * @copyright  Dan Poltawski
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package   local_chatlogs
+ * @copyright 2017 Dan Poltawski <dan@moodle.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'local_chatlogs';
-$plugin->release = '3.2.0';
-$plugin->version = 2017012900;
-$plugin->requires = 2016112500;
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = array(
-    'filter_urltolink' => 2015051100,
+$tasks = array(
+    array(
+        'classname' => 'local_chatlogs\task\sync_chatlogs',
+        'blocking' => 0,
+        'minute' => '*/5',
+        'hour' => '*',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*'
+    )
 );

--- a/lang/en/local_chatlogs.php
+++ b/lang/en/local_chatlogs.php
@@ -22,6 +22,10 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 $string['allconversations'] = 'All conversations';
+$string['apisecret'] = 'API Secret';
+$string['apisecretdescription'] = 'The shared secret needed to access the API.';
+$string['apiurl'] = 'API URL';
+$string['apiurldescription'] = 'The url to the telegram logbot api to retrieve room messages. When set this will stop the existing direct direct DB sync from operating';
 $string['chatlogs:manage'] = 'Manage the developer chat logs plugin';
 $string['chatlogs:view'] = 'View developer chat logs irrespective of cohort membership';
 $string['chatlogs:viewifdeveloper'] = 'View developer chat logs if in developer cohort';
@@ -36,4 +40,5 @@ $string['jabberfullname'] = 'Jabber Nick';
 $string['pluginname'] = 'Developer chat';
 $string['searchchat'] = 'Search chat history';
 $string['searchmessages'] = 'Search messages';
+$string['syncchatlogs'] = 'Sync chatlogs';
 $string['viewchatlogs'] = 'View chat logs';

--- a/settings.php
+++ b/settings.php
@@ -32,5 +32,13 @@ if (has_capability('moodle/site:config', context_system::instance())) {
     $temp->add(new local_chatlogs_cohort_selector('local_chatlogs/cohortid', get_string('developercohort', 'local_chatlogs'),
         get_string('developercohortdescription', 'local_chatlogs'), 0, null));
 
+    $temp->add(new admin_setting_configtext('local_chatlogs/apiurl', new lang_string('apiurl', 'local_chatlogs'),
+        new lang_string('apiurldescription', 'local_chatlogs'), '', PARAM_URL));
+
+    $temp->add(new admin_setting_configpasswordunmask('local_chatlogs/apisecret',
+        new lang_string('apisecret', 'local_chatlogs'),
+        new lang_string('apisecretdescription', 'local_chatlogs'), ''));
+
+
     $ADMIN->add('localplugins', $temp);
 }

--- a/syncchatlogs.php
+++ b/syncchatlogs.php
@@ -27,6 +27,10 @@ if (isset($_SERVER['REMOTE_ADDR'])) {
     }
 }
 
+$apiurl = get_config('local_chatlogs', 'apiurl');
+if (!empty($apiurl)) {
+    die("local_chatlogs/apiurl is set, please use the scheduled task instead.\n");
+}
 
 $CONVERSATIONGAP = 30 * 60;   // 30 minutes gap
 

--- a/tests/telegram_importer_test.php
+++ b/tests/telegram_importer_test.php
@@ -142,6 +142,23 @@ class local_chatlogs_telegram_importer_test extends advanced_testcase {
         // 1 extra participant.
         $this->assertSame(2, $DB->count_records('local_chatlogs_participants'));
     }
+
+    public function test_problematic_mysql_emojis() {
+        global $DB;
+        $this->resetAfterTest();
+
+        // Run initial import of 2 messages.
+        $importer = new local_chatlogs_testable_telegram_importer();
+        $importer->set_mock_response([
+            ['username' => 'davidm', 'fullname' => 'DavidMonllao', 'message' => '👍', 'timestamp' => '2017-01-29T12:31:37.601Z'],
+        ]);
+
+        // To messages imported.
+        $importedcount = $importer->import();
+        $this->assertSame(1, $importedcount);
+        $this->assertSame(1, $DB->count_records('local_chatlogs_messages'));
+    }
+
 }
 
 /**

--- a/tests/telegram_importer_test.php
+++ b/tests/telegram_importer_test.php
@@ -1,0 +1,202 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+/**
+ * Telegram importer tests.
+ *
+ * @package local_chatlogs
+ * @copyright 2017 Dan Poltawski
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class local_chatlogs_telegram_importer_test extends advanced_testcase {
+
+    public function test_import_when_empty() {
+        $this->resetAfterTest();
+
+        $importer = new local_chatlogs_testable_telegram_importer();
+        $importer->set_mock_response([]);
+        $importedcount  = $importer->import();
+        $this->assertEmpty($importedcount);
+    }
+
+    public function test_import_fails_on_bad_json() {
+        $this->resetAfterTest();
+        $importer = new local_chatlogs_testable_telegram_importer();
+        $importer->set_mock_response('{sdfs:sdf');
+
+        $this->expectException(moodle_exception::class);
+        $importer->import();
+    }
+
+    public function test_import() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $this->assertEmpty($DB->count_records('local_chatlogs_messages'));
+        $this->assertEmpty($DB->count_records('local_chatlogs_conversations'));
+        $this->assertEmpty($DB->count_records('local_chatlogs_participants'));
+
+        // Run initial import of 2 messages.
+        $importer = new local_chatlogs_testable_telegram_importer();
+        $importer->set_mock_response([
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'First message from Dan', 'timestamp' => '2017-01-29T12:30:37.601Z'],
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'Second message from Dan', 'timestamp' => '2017-01-29T12:31:37.601Z'],
+        ]);
+
+        // To messages imported.
+        $importedcount = $importer->import();
+        $this->assertSame(2, $importedcount);
+
+        // Run the import again. We should not get duplicate messages imported.
+        $importedcount = $importer->import();
+        $this->assertEmpty($importedcount);
+
+        // Simulate a message added by Joe Bloggs.
+        $importer->set_mock_response([
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'First message from Dan', 'timestamp' => '2017-01-29T12:30:37.601Z'],
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'Second message from Dan', 'timestamp' => '2017-01-29T12:31:37.601Z'],
+            ['username' => 'joeblogs', 'fullname' => 'Dan P', 'message' => 'Response from Joe', 'timestamp' => '2017-01-29T12:32:37.601Z'],
+        ]);
+
+        // Now we've got an extra message to import.
+        $importedcount = $importer->import();
+        $this->assertSame(1, $importedcount);
+
+        // Verify db tables have been up updated.
+        $this->assertSame(3, $DB->count_records('local_chatlogs_messages'));
+        $this->assertSame(1, $DB->count_records('local_chatlogs_conversations'));
+        $this->assertSame(2, $DB->count_records('local_chatlogs_participants'));
+
+        // Simulate a chat message sent the next day, this should create a new conversation record.
+        $importer->set_mock_response([
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'First message from Dan', 'timestamp' => '2017-01-29T12:30:37.601Z'],
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'Second message from Dan', 'timestamp' => '2017-01-29T12:31:37.601Z'],
+            ['username' => 'joeblogs', 'fullname' => 'Joe B', 'message' => 'Response from Joe', 'timestamp' => '2017-01-29T12:32:37.601Z'],
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'Sorry Joe!', 'timestamp' => '2017-01-30T12:32:37.601Z'],
+        ]);
+
+        $importedcount = $importer->import();
+        // Should only be the one new message to import.
+        $this->assertSame(1, $importedcount);
+
+        // And now two conversation records.
+        $this->assertSame(2, $DB->count_records('local_chatlogs_conversations'));
+    }
+
+    public function test_import_with_existing_data() {
+        global $DB;
+        $this->resetAfterTest();
+        // Insert some chatlog data.
+        $conversations = [
+            ['conversationid' => '1', 'timestart' => '1358138860', 'timeend' => '1358140681', 'messagecount' => 2],
+            ['conversationid' => '2', 'timestart' => '1358142505', 'timeend' => '1358142507', 'messagecount' => 1],
+        ];
+        $DB->insert_records('local_chatlogs_conversations', $conversations);
+        $messages = [
+            ['conversationid' => '1', 'fromemail' => 'danpoltawski@telegram.me', 'timesent' => '1358138860', 'timejava' => '1358138860000', 'message' => 'Testing'],
+            ['conversationid' => '1', 'fromemail' => 'danpoltawski@telegram.me', 'timesent' => '1358138958', 'timejava' => '1358138958000', 'message' => 'Testing'],
+            ['conversationid' => '2', 'fromemail' => 'danpoltawski@telegram.me', 'timesent' => '1358142505', 'timejava' => '1358142505000', 'message' => '123'],
+        ];
+        $DB->insert_records('local_chatlogs_messages', $messages);
+
+        $participants = [
+            ['fromemail' => 'danpoltawski@telegram.me', 'nickname' => 'danpoltawski'],
+        ];
+        $DB->insert_records('local_chatlogs_participants', $participants);
+
+        $this->assertSame(3, $DB->count_records('local_chatlogs_messages'));
+        $this->assertSame(2, $DB->count_records('local_chatlogs_conversations'));
+        $this->assertSame(1, $DB->count_records('local_chatlogs_participants'));
+
+        // Run import of new 2 messages.
+        $importer = new local_chatlogs_testable_telegram_importer();
+        $importer->set_mock_response([
+            ['username' => 'danpoltawski', 'fullname' => 'Dan P', 'message' => 'First message from Dan', 'timestamp' => '2017-01-29T12:30:37.601Z'],
+            ['username' => 'bob', 'fullname' => 'Bob', 'message' => 'Message from Bob', 'timestamp' => '2017-01-29T12:31:37.601Z'],
+        ]);
+
+        $importedcount = $importer->import();
+        $this->assertSame(2, $importedcount);
+
+        // 2 extra messages.
+        $this->assertSame(5, $DB->count_records('local_chatlogs_messages'));
+        // 1 extra conversation.
+        $this->assertSame(3, $DB->count_records('local_chatlogs_conversations'));
+        // 1 extra participant.
+        $this->assertSame(2, $DB->count_records('local_chatlogs_participants'));
+    }
+}
+
+/**
+ * Testable importer which generates mock server response.
+ * @package local_chatlogs
+ * @copyright 2017 Dan Poltawski
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class local_chatlogs_testable_telegram_importer extends local_chatlogs\telegram_importer {
+    /** @var string|array mock response */
+    private $mockresponse = null;
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        parent::__construct('https://example.org/api/', 'secret');
+    }
+
+    /**
+     * Mocking response from simple json api from https://github.com/danpoltawski/hubot-log-to-pgsql
+     * @param \moodle_url $url to call
+     * @return string
+     */
+    protected function call_api(\moodle_url $url) {
+        if (is_string($this->mockresponse)) {
+            // Allow simulation of bad json etc.
+            return $this->mockresponse;
+        }
+
+        // Simulate server-side filtering of timestamp.
+        if ($timestamp = $url->param('aftertimestamp')) {
+            $afterdate = new DateTime($timestamp);
+            $resp = array_filter($this->mockresponse, function ($row) use($afterdate) {
+                return new DateTime($row->timestamp) > $afterdate;
+            });
+            return json_encode($resp);
+        }
+
+        return json_encode($this->mockresponse);
+    }
+
+    /**
+     * Set mock response for importer api call
+     * @param string|array $data
+     */
+    public function set_mock_response($data) {
+        if (is_string($data)) {
+            $this->mockresponse = $data;
+            return;
+        }
+
+        $this->mockresponse = [];
+        foreach ($data as $row) {
+            $this->mockresponse[] = (object) $row;
+        }
+    }
+}


### PR DESCRIPTION
* Introduce some new configuration settings which allow the configuration of a REST api endpoint provided by hubot-log-to-pgsql, which superceeds the exist direct db call to retrieve logs

* Add scheduled task to retreieve logs from the api endpoint

* Stop the existing direct DB connection sync from operating when the api endpoint is configured in settings

* Note that the import logic mostly matches the existing syncchatlogs.php logic entirely, with the exception of 'orphan logs' handling, which is buggy according to #8 and perhaps is best avoiding all together

* Add some unit test coverage (and enable travis on this repo)

We are (hopefully) going to test this out on integration team site soon